### PR TITLE
Add build script for macOS arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ build-linux: clean
 	${BUILD_ENV} GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o build/${APP}-${VERSION}_linux_amd64 main.go
 build-osx: clean
 	${BUILD_ENV} GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o build/${APP}-${VERSION}_osx_amd64 main.go
+build-osx-arm64: clean
+	${BUILD_ENV} GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o build/${APP}-${VERSION}_osx_amd64 main.go
 build-win64: clean
 	${BUILD_ENV} GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o build/${APP}-${VERSION}_win64.exe main.go
 build-win32: clean

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ go 1.20
 make build-linux
 # 编译目标平台: mac
 make build-osx
+# 编译目标平台: mac Arm64 (M1 Pro)
+make build-osx-arm64
 # 编译目标平台: windows 64位
 make build-win64
 # 编译目标平台: windows 32位


### PR DESCRIPTION
I tested the build on macOS M1 Pro.
Fix #https://github.com/fengxxc/wechatmp2markdown/issues/6